### PR TITLE
Allow hostname to be provided by env DISCOVERY_HOSTNAME

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -8,7 +8,7 @@ var dgram = require('dgram'),
     nodeVersion = process.version.replace('v','').split(/\./gi).map(function (t) { return parseInt(t, 10) });
 
 var procUuid = uuid.v4();
-var hostName = os.hostname();
+var hostName = process.env.DISCOVERY_HOSTNAME || os.hostname();
 
 module.exports = Network;
 


### PR DESCRIPTION
This allows discovery and communication in a restrictive network setup (e.g. kubernetes) where neither broadcast or multicast are available