### PR TITLE
Allow hostname to be passed in

### DIFF
--- a/lib/discover.js
+++ b/lib/discover.js
@@ -122,7 +122,7 @@ function Discover (options, callback) {
 		ignoreProcess  : settings.ignoreProcess,
 		ignoreInstance  : settings.ignoreInstance,
 		redis       : settings.redis,
-    hostname: options.hostname,
+		hostname	: options.hostname,
 	});
 
 	//This is the object that gets broadcast with each hello packet.

--- a/lib/discover.js
+++ b/lib/discover.js
@@ -121,7 +121,8 @@ function Discover (options, callback) {
 		reuseAddr	: settings.reuseAddr,
 		ignoreProcess  : settings.ignoreProcess,
 		ignoreInstance  : settings.ignoreInstance,
-		redis       : settings.redis
+		redis       : settings.redis,
+    hostname: options.hostname,
 	});
 
 	//This is the object that gets broadcast with each hello packet.


### PR DESCRIPTION

Some of our nodes have hostnames determined at runtime and cannot be placed in the .env. We also can't update process.env.DISCOVERY_HOSTNAME, because the variable is captured [on import](https://github.com/dashersw/node-discover/blob/master/lib/network.js#L11) instead of on instantiation. This small change allows the hostname to be determined by the consumer of the library.